### PR TITLE
fix: use setup.py-only configuration for maximum compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,35 +1,3 @@
-[project]
-name = "openvpn-manager"
-version = "0.2.3"
-description = "A PyQt6-based OpenVPN connection manager"
-readme = "README.md"
-requires-python = ">=3.10"
-dependencies = [
-    "PyQt6>=6.4.0",
-]
-authors = [
-    {name = "Iágson Carlos Lima Silva", email = "iagsoncarlos@gmail.com"}
-]
-classifiers = [
-    "Development Status :: 3 - Alpha",
-    "Intended Audience :: End Users/Desktop",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Operating System :: POSIX :: Linux",
-    "Topic :: System :: Networking",
-]
-
-[project.scripts]
-openvpn-manager = "main:main"
-
-[project.urls]
-"Homepage" = "https://github.com/iagsoncarlos/openvpn-manager"
-"Bug Reports" = "https://github.com/iagsoncarlos/openvpn-manager/issues"
-"Source" = "https://github.com/iagsoncarlos/openvpn-manager"
-
 [build-system]
 requires = ["setuptools>=45", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from setuptools import setup, find_packages
+from setuptools import setup
 import os
 
 # Read version from VERSION file
@@ -17,11 +17,12 @@ setup(
     name="openvpn-manager",
     version=get_version(),
     description="A PyQt6-based OpenVPN connection manager",
+    long_description="OpenVPN Manager with bundled dependencies for offline installation.",
     author="Iágson Carlos Lima Silva",
     author_email="iagsoncarlos@gmail.com",
     url="https://github.com/iagsoncarlos/openvpn-manager",
     py_modules=["main", "config"],
-    install_requires=[],  # No external dependencies
+    install_requires=[],  # No external dependencies for .deb build
     entry_points={
         "console_scripts": [
             "openvpn-manager=main:main",
@@ -39,10 +40,11 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.11", 
         "Programming Language :: Python :: 3.12",
         "Operating System :: POSIX :: Linux",
         "Topic :: System :: Networking",
     ],
     python_requires=">=3.10",
+    license="MIT",
 )


### PR DESCRIPTION
- Remove conflicting [project] section from pyproject.toml
- Use minimal pyproject.toml with only [build-system]
- Configure all metadata in setup.py for better compatibility
- Avoid license-files and other modern pyproject.toml features
- This should work with older setuptools versions in CI environments

Tested locally with python -m build --sdist and works correctly.